### PR TITLE
Properly retrieving the version of the project from the package.json …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@ep-npm/fonda",
+  "version": "0.0.1",
   "description": "Utility for transforming Terraform variables to environment variables.",
   "license": "Apache-2.0",
   "author": "Elastic Path Software",

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
       process)))
 
 (def +version+
-  (-> (ProcessBuilder. ["yarn" "version" "--version"])
+  (-> (ProcessBuilder. ["scripts/get-version.sh"])
       (.start)
       (throw-if-non-zero)
       (.getInputStream)

--- a/scripts/get-version.sh
+++ b/scripts/get-version.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+PACKAGE_VERSION=$(sed -nE 's/^\s*"version": "(.*?)",$/\1/p' package.json)
+echo $PACKAGE_VERSION


### PR DESCRIPTION
Created a bash script to retrieve the version from package.json, and project.clj is using now that script. With the previous script we were just retrieving the yarn version, not the project version