### PR TITLE
Avoid deploying dev and test files

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,6 @@
 {:paths   ["src"]
- :deps    {}
  :aliases {:test {:extra-paths ["test"]}
-           :dev  {:extra-paths ["dev"]
-                  :extra-deps  {org.clojure/clojure       {:mvn/version "1.10.0-beta6"}
+           :dev  {:extra-deps  {org.clojure/clojure       {:mvn/version "1.10.0-beta6"}
                                 org.clojure/clojurescript {:mvn/version "1.10.439"}
                                 expound                   {:mvn/version "0.7.1"}
                                 org.clojure/test.check    {:mvn/version "0.10.0-alpha3" :exclusions [org.clojure/clojure]}

--- a/project.clj
+++ b/project.clj
@@ -25,16 +25,20 @@
   :license {:name "Apache License"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :source-paths ["src"]
-  :test-paths ["test"]
   :resource-paths []
   :compile-path nil
   :target-path nil
   :plugins [[lein-tools-deps "0.4.1"]]
   :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
-  :lein-tools-deps/config {:config-files [:install :user :project]
-                           :aliases [:dev :test]}
+  :lein-tools-deps/config {:config-files [:project]}
 
+  ;; unsigned SHAPSHOTs only deployed CI
+  ;; signed releases will be manually deployed
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
                                     :username :env/clojars_username
                                     :password :env/clojars_password
-                                    :sign-releases false}]])
+                                    :sign-releases false}]]
+
+  :profiles {:dev {:test-paths ["test"]
+                   :lein-tools-deps/config {:config-files [:install :user :project]
+                                            :aliases [:dev :test]}}})


### PR DESCRIPTION
The current project.clj uses the dev and test aliases and therefore packs
unnecessary files in the jar. This patch changes that so that we only deploy
"src".