### PR TITLE
[Fix #21] Remove the ctx parameter to execute

### DIFF
--- a/src/fonda/core.cljs
+++ b/src/fonda/core.cljs
@@ -19,7 +19,6 @@
 (s/fdef execute
   :args (s/cat :config ::config
                :steps ::steps
-               :context ::r/ctx
                :on-success ::r/on-success
                :on-anomaly ::r/on-anomaly
                :on-exception ::r/on-exception))
@@ -33,7 +32,7 @@
       - [opt] log-exception A function gets called with the FondaContext record when there is an exception.
       - [opt] log-anomaly   A function that gets called with the FondaContext record when a step returns an anomaly.
       - [opt] log-success   A function that gets called with the FondaContext record after all steps succeeded.
-      - [opt] initial-ctx   The context data initializes the context. Must be a map.
+      - [opt] initial-ctx   The data that initializes the context. Must be a map.
 
   - `steps`: Each item on the `steps` collection must be either a Tap, or a Processor.
 
@@ -46,11 +45,10 @@
        - path:     Path where to assoc the result of the processor
        - name:     The name of the step
 
-  - `ctx`          The runtime context, merged to the initial context. Must be a map.
   - `on-success`   Callback that gets called with the context if all the steps succeeded.
   - `on-anomaly`   Callback that gets called with an anomaly when any step returns one.
   - `on-exception` Callback that gets called with an exception when any step triggers one."
-  ([config steps ctx on-success on-anomaly on-exception]
+  ([config steps on-success on-anomaly on-exception]
 
    (let [{:keys [anomaly?
                  log-exception
@@ -62,7 +60,7 @@
            :log-exception log-exception
            :log-anomaly   log-anomaly
            :log-success   log-success
-           :ctx           (merge (:initial-ctx config) ctx)
+           :ctx           (or (:initial-ctx config) {})
            :on-success    on-success
            :on-anomaly    on-anomaly
            :on-exception  on-exception

--- a/src/fonda/runtime.cljs
+++ b/src/fonda/runtime.cljs
@@ -8,7 +8,6 @@
 (s/def ::log-anomaly (s/nilable fn?))
 (s/def ::log-success (s/nilable fn?))
 (s/def ::initial-ctx map?) ;; part of the config
-(s/def ::ctx map?)
 (s/def ::exception (s/nilable #(instance? js/Error %)))
 (s/def ::anomaly (s/nilable any?))
 (s/def ::on-success fn?)

--- a/test/fonda/loggers_test.cljs
+++ b/test/fonda/loggers_test.cljs
@@ -35,9 +35,9 @@
           log-anomaly (fn [{:keys [stack]}]
                         (is (= (:name processor) (:name (last stack)))) (done))]
       (fonda/execute {:log-anomaly log-anomaly}
-                     [processor] {}
+                     [processor]
                      success-cb-throw
-                     (fn [_])                               ;; Anomaly callbacks are tested elsewhere
+                     (fn [_]) ;; Anomaly callbacks are tested elsewhere
                      exception-cb-throw))))
 
 (deftest log-exception-gets-steps-stack-test
@@ -48,10 +48,10 @@
           log-exception (fn [{:keys [stack]}]
                           (is (= (:name processor) (:name (last stack)))) (done))]
       (fonda/execute {:log-exception log-exception}
-                     [processor] {}
+                     [processor]
                      success-cb-throw
                      anomaly-cb-throw
-                     (fn [_])))))                           ;; Exception callbacks are tested elsewhere
+                     (fn [_]))))) ;; Exception callbacks are tested elsewhere
 
 (deftest log-success-gets-steps-stack-test
   (async done
@@ -61,8 +61,8 @@
           log-success (fn [{:keys [stack]}]
                         (is (= (:name processor) (:name (last stack)))) (done))]
       (fonda/execute {:log-success log-success}
-                     [processor] {}
-                     (fn [_])                               ;; Success callbacks are tested elsewhere
+                     [processor]
+                     (fn [_]) ;; Success callbacks are tested elsewhere
                      anomaly-cb-throw
                      exception-cb-throw))))
 
@@ -82,7 +82,7 @@
                        (is (true? @log-success-run?))
                        (done))]
       (fonda/execute {:log-success log-success}
-                     [processor] {}
+                     [processor]
                      success-cb
                      anomaly-cb-throw
                      exception-cb-throw))))
@@ -103,7 +103,7 @@
                        (is (true? @log-anomaly-run?))
                        (done))]
       (fonda/execute {:log-anomaly log-anomaly}
-                     [processor] {}
+                     [processor]
                      success-cb-throw
                      anomaly-cb
                      exception-cb-throw))))
@@ -124,7 +124,7 @@
                          (is (true? @log-exception-run?))
                          (done))]
       (fonda/execute {:log-exception log-exception}
-                     [processor] {}
+                     [processor]
                      success-cb-throw
                      anomaly-cb-throw
                      exception-cb))))
@@ -139,8 +139,8 @@
                         (is (= processor (select-keys (last stack) [:path :name :processor])))
                         (done))]
       (fonda/execute {:log-success log-success}
-                     [processor] {}
-                     (fn [_])                               ;; ;; Success callbacks are tested elsewhere
+                     [processor]
+                     (fn [_]) ;; Success callbacks are tested elsewhere
                      anomaly-cb-throw
                      exception-cb-throw))))
 
@@ -155,9 +155,9 @@
                         (is (= anomaly returned-anomaly))
                         (done))]
       (fonda/execute {:log-anomaly log-anomaly}
-                     [processor] {}
+                     [processor]
                      success-cb-throw
-                     (fn [_])                               ;; Anomaly callbacks are tested elsewhere
+                     (fn [_]) ;; Anomaly callbacks are tested elsewhere
                      exception-cb-throw))))
 
 (deftest log-exception-gets-stack-and-exception-test
@@ -171,7 +171,7 @@
                           (is (= exception thrown-exception))
                           (done))]
       (fonda/execute {:log-exception log-exception}
-                     [processor] {}
+                     [processor]
                      success-cb-throw
                      anomaly-cb-throw
-                     (fn [_])))))                           ;; Exception callbacks are tested elsewhere
+                     (fn [_]))))) ;; Exception callbacks are tested elsewhere


### PR DESCRIPTION
It proved itself to be unnecessary given we have :initial-ctx. This is a
breaking change.