### PR TITLE
Make the name key for step optional and possibly a keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Resolve qualified keywords to step functions. [#32](https://github.com/elasticpath/fonda/pull/32).
+- Resolve qualified keywords to step functions. [#32](https://github.com/elasticpath/fonda/pull/32)
+- Make the name key for step optional and possibly a keyword. [#33](https://github.com/elasticpath/fonda/pull/33)
 
 ## [v0.2.1](https://github.com/elasticpath/fonda/compare/v0.0.2...v0.2.1) - 2018-02-12
 

--- a/src/fonda/step.cljs
+++ b/src/fonda/step.cljs
@@ -3,9 +3,9 @@
             [fonda.meta :as meta]))
 
 ;; Common for all steps
-(s/def ::name (s/or :k keyword? :s string?))
+(s/def ::name string?)
 (s/def ::step-common
-  (s/keys :req-un [::name]))
+  (s/keys :opt-un [::name]))
 
 ;; Tap step
 (s/def ::tap (s/or :function fn? :qualified-keyword qualified-keyword?))


### PR DESCRIPTION
Rarely you need the name in a step, at least in our use cases, so it becomes
optional for name. It also can be a keyword, which unifies with the step
function new resolution method.