### PR TITLE
[Fix #24] Make short-circuiting for anomalies optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [master](https://github.com/elasticpath/fonda/compare/v0.2.1...HEAD) - UNRELEASED
 
+### Changed
+
+- Make short-circuiting for anomalies optional. [#38](https://github.com/elasticpath/fonda/pull/38)
+- Change `fonda.core/execute` signature to `(fn [config steps on-exception on-success & on-anomaly])`. [#38](https://github.com/elasticpath/fonda/pull/38)
+
 ### Added
 
 - Resolve qualified keywords to step functions. [#32](https://github.com/elasticpath/fonda/pull/32)

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -11,9 +11,11 @@
           :test {:target    :node-test
                  :output-to "dist/test.js"
                  :autorun   true
+                 :devtools  {:preloads [fonda.test-preload]}
                  :release   {:compiler-options {:optimizations     :simple
                                                 :variable-renaming :off
                                                 :property-renaming :off
                                                 :pretty-print      true
-                                                :source-map        true}
+                                                :source-map        true
+                                                :elide-asserts     false}
                              :autorun          false}}}}

--- a/src/fonda/anomaly.cljs
+++ b/src/fonda/anomaly.cljs
@@ -1,4 +1,0 @@
-(ns fonda.anomaly)
-
-(defn anomaly? [m]
-  (some? (get m :cognitect.anomalies/anomaly)))

--- a/src/fonda/core.cljs
+++ b/src/fonda/core.cljs
@@ -1,6 +1,5 @@
 (ns fonda.core
   (:require [clojure.spec.alpha :as s]
-            [fonda.anomaly]
             [fonda.execute :as e]
             [fonda.step :as st]))
 
@@ -13,11 +12,11 @@
 
   Each step function - tap or processor - can be synchronous or asynchronous.
 
-  - `config`: A map with:
+  - config: A map with:
       - [opt] anomaly?      A function that gets a map and determines if it is an anomaly.
       - [opt] initial-ctx   The data that initializes the context. Must be a map.
 
-  - `steps`: Each item on the `steps` collection must be either a Tap, or a Processor.
+  - steps: Each item on the `steps` collection must be either a Tap, or a Processor.
 
       Tap:
        - tap:  A function that gets the context but doesn't augment it.
@@ -28,17 +27,17 @@
        - path:     Path where to assoc the result of the processor
        - name:     The name of the step
 
-  - `on-success`   Callback that gets called with the context if all the steps succeeded.
-  - `on-anomaly`   Callback that gets called with an anomaly when any step returns one.
-  - `on-exception` Callback that gets called with an exception when any step triggers one."
-  ([config steps on-success on-anomaly on-exception]
-   (-> (e/map->FondaContext
-        {:anomaly?      (or (:anomaly? config) fonda.anomaly/anomaly?)
-         :ctx           (or (:initial-ctx config) {})
-         :on-success    on-success
-         :on-anomaly    on-anomaly
-         :on-exception  on-exception
-         :queue         (into #queue [] st/xf steps)
-         :stack         []})
+  - on-success   Callback that gets called with the context if all the steps succeeded.
+  - on-exception Callback that gets called with an exception when any step triggers one.
+  - [opt] on-anomaly   Callback that gets called with an anomaly when any step returns one."
+  ([config steps on-exception on-success]
+   (execute config steps on-exception on-success nil))
+  ([config steps on-exception on-success on-anomaly]
+   (-> config
+       (merge {:steps        steps
+               :on-anomaly   on-anomaly
+               :on-exception on-exception
+               :on-success   on-success})
+       (e/fonda-context)
        (e/execute-steps)
        (e/deliver-result))))

--- a/src/fonda/core/specs.cljc
+++ b/src/fonda/core/specs.cljc
@@ -2,26 +2,26 @@
   (:require [clojure.spec.alpha :as s]
             [fonda.step.specs :as step]))
 
-(s/def ::anomaly? (s/nilable fn?))
-(s/def ::initial-ctx map?) ;; part of the config
-(s/def ::exception (s/nilable #(instance? js/Error %)))
-(s/def ::anomaly (s/nilable any?))
+;; Config
+(s/def ::anomaly? (s/or :boolean boolean? :predicate fn?))
+(s/def ::initial-ctx map?)
+
 (s/def ::on-success fn?)
 (s/def ::on-exception fn?)
-(s/def ::on-anomaly fn?)
+(s/def ::on-anomaly (s/nilable fn?))
 
 (s/def ::step
   (s/or :tap-step ::step/tap-step
         :processor-step ::step/processor-step))
 
-(s/def ::steps (s/coll-of ::step/step))
+(s/def ::steps (s/coll-of ::step))
 
 (s/def ::config
-  (s/keys :opt-un [::anomaly?]))
+  (s/keys :opt-un [::anomaly? ::initial-ctx]))
 
-(s/fdef execute
+(s/fdef fonda.core/execute
   :args (s/cat :config ::config
                :steps ::steps
+               :on-exception ::on-exception
                :on-success ::on-success
-               :on-anomaly ::on-anomaly
-               :on-exception ::on-exception))
+               :on-anomaly (s/? ::on-anomaly)))

--- a/src/fonda/execute/specs.cljc
+++ b/src/fonda/execute/specs.cljc
@@ -2,20 +2,26 @@
   (:require [clojure.spec.alpha :as s]
             [fonda.step.specs :as step]))
 
+;; the following are all required but nilable we use a record as FondaContext.
+
+(s/def ::anomaly-fn (s/nilable fn?))
+(s/def ::exception (s/nilable #(instance? js/Error %)))
+(s/def ::anomaly (s/nilable any?))
 (s/def ::queue (s/coll-of ::step))
 (s/def ::stack (s/coll-of ::step))
 
-(s/def ::fonda-context-async a/async?)
+(s/def ::fonda-context-async some?)
+
 (s/def ::fonda-context-sync
-  (s/keys :req-un [::anomaly?
-                   ::ctx
+  (s/keys :req-un [::ctx
                    ::on-success
                    ::on-anomaly
                    ::on-exception
                    ::queue
                    ::stack
                    ::exception
-                   ::anomaly]))
+                   ::anomaly
+                   ::anomaly-fn]))
 
 (s/def ::fonda-context (s/or :async ::fonda-context-async
                              :sync ::fonda-context-sync))

--- a/test/fonda/core_test.cljs
+++ b/test/fonda/core_test.cljs
@@ -1,20 +1,20 @@
 (ns fonda.core-test
   (:require [cljs.test :refer-macros [deftest is testing async]]
-            [fonda.anomaly]
             [fonda.core :as fonda]
             [fonda.core.specs]
+            [fonda.execute.specs]
             [orchestra-cljs.spec.test :as orchestra]))
 
 (orchestra/instrument)
 
 (defn success-cb-throw [res]
-  (throw (js/Error (str "not excepted success callback called with res:" res))))
+  (throw (js/Error (str "unexpected success callback called with res:" res))))
 
 (defn exception-cb-throw [err]
   (throw err))
 
 (defn anomaly-cb-throw [anomaly]
-  (throw (js/Error (str "not expected anomaly callback called with anomaly:" anomaly))))
+  (throw (js/Error (str "unexpected anomaly callback called with anomaly:" anomaly))))
 
 (defn anomaly
   ([category]
@@ -26,11 +26,12 @@
 (deftest execute-empty-chain-test-1
   (testing "Passing empty configuration with empty steps should call on-success with a nil value."
     (async done
-      (fonda/execute {} []
+      (fonda/execute {}
+                     []
+                     exception-cb-throw
                      (fn [res]
-                       (is (= {} res)) (done))
-                     anomaly-cb-throw
-                     exception-cb-throw))))
+                       (is (= {} res))
+                       (done))))))
 
 (deftest execute-empty-chain-test-2
   (testing "Passing a context on the configuration with empty steps should call on-success with that context."
@@ -38,141 +39,141 @@
       (async done
         (fonda/execute {:initial-ctx initial}
                        []
-                       (fn [res] (is (= initial res)) (done))
-                       anomaly-cb-throw
-                       exception-cb-throw)))))
+                       exception-cb-throw
+                       (fn [res]
+                         (is (= initial res))
+                         (done)))))))
 
 (deftest one-successful-sync-processor-test
-  (testing "Passing one synchronous processor should call on-success with the context augmented with the processor result
-  on the processor path."
+  (testing "Passing one synchronous processor should call on-success with the context augmented with the processor result on the processor path."
     (async done
       (let [processor-res 42
             processor-path [:processor-path]
             processor {:path      processor-path
-                       :name      "processor name"
-                       :processor (fn [_] processor-res)}]
+                       :processor (constantly processor-res)}]
         (fonda/execute {}
                        [processor]
-                       (fn [res] (is (= processor-res (get-in res processor-path))) (done))
-                       anomaly-cb-throw
-                       exception-cb-throw)))))
+                       exception-cb-throw
+                       (fn [res]
+                         (is (= processor-res (get-in res processor-path)))
+                         (done)))))))
 
 (deftest one-successful-sync-tap-doesnt-augment-context-test
   (testing "Passing one synchronous tap should call on-success with the initial context"
     (async done
       (let [initial {:foo :bar}
             tap {:name "tap1"
-                 :tap  (fn [_] :whatever-value)}]
-        (fonda/execute {:initial-ctx initial} [tap]
-                       (fn [res] (is (= initial res)) (done))
-                       anomaly-cb-throw
-                       exception-cb-throw)))))
+                 :tap  (constantly :whatever-value)}]
+        (fonda/execute {:initial-ctx initial}
+                       [tap]
+                       exception-cb-throw
+                       (fn [res]
+                         (is (= initial res))
+                         (done)))))))
 
 (deftest one-successful-sync-tap-is-passed-the-context
   (testing "Passing one synchronous tap should call on-success with the initial context"
     (async done
       (let [initial {:foo :bar}
-            tap {:name "tap1"
-                 :tap  (fn [ctx]
-                         (is (= initial ctx)) (done)
-                         :whatever-value)}]
+            tap {:tap  (fn [ctx]
+                         (is (= initial ctx))
+                         (done))}]
         (fonda/execute {:initial-ctx initial}
                        [tap]
-                       (fn [_])
-                       anomaly-cb-throw
-                       exception-cb-throw)))))
+                       exception-cb-throw
+                       (fn [_]))))))
 
 (deftest one-successful-async-processor-test
-  (testing "Passing one asynchronous processor should call on-success with the context augmented with the processor result
-  on the processor path."
+  (testing "Passing one asynchronous processor should call on-success with the context augmented with the processor result on the processor path."
     (async done
       (let [processor-res 42
             processor-path [:processor-path]
             processor {:path      processor-path
-                       :name      "processor name"
-                       :processor (fn [_] (js/Promise.resolve processor-res))}]
+                       :processor (constantly (js/Promise.resolve processor-res))}]
         (fonda/execute {}
                        [processor]
-                       (fn [res] (is (= processor-res (get-in res processor-path))) (done))
-                       anomaly-cb-throw
-                       exception-cb-throw)))))
+                       exception-cb-throw
+                       (fn [res]
+                         (is (= processor-res (get-in res processor-path)))
+                         (done)))))))
 
 (deftest one-unsuccessful-sync-processor-test
   (testing "Passing one synchronous unsuccessful processor should call on-anomaly with the anomaly"
     (async done
       (let [processor-res (anomaly :cognitect.anomalies/incorrect)
             processor {:path      [:processor-path]
-                       :name      "processor name"
-                       :processor (fn [_] processor-res)}]
-        (fonda/execute {}
+                       :processor (constantly processor-res)}]
+        (fonda/execute {:anomaly? true}
                        [processor]
+                       exception-cb-throw
                        (fn [_])
-                       (fn [anomaly] (is (= processor-res anomaly)) (done))
-                       exception-cb-throw)))))
+                       (fn [anomaly] (is (= processor-res anomaly)) (done)))))))
 
 (deftest one-unsuccessful-sync-tap-test
   (testing "Passing one synchronous unsuccessful tap should call on-anomaly with the anomaly"
     (async done
       (let [tap-res (anomaly :cognitect.anomalies/incorrect)
             tap {:path [:processor-path]
-                 :name "processor name"
-                 :tap  (fn [_] tap-res)}]
-        (fonda/execute {}
+                 :tap  (constantly tap-res)}]
+        (fonda/execute {:anomaly? true}
                        [tap]
+                       exception-cb-throw
                        success-cb-throw
-                       (fn [anomaly] (is (= tap-res anomaly)) (done))
-                       exception-cb-throw)))))
+                       (fn [anomaly]
+                         (is (= tap-res anomaly))
+                         (done)))))))
 
 (deftest one-unsuccessful-async-processor-test
   (testing "Passing one asynchronous unsuccessful processor should call on-anomaly with the anomaly"
     (async done
       (let [processor-res (anomaly :cognitect.anomalies/incorrect)
             processor {:path      [:processor-path]
-                       :name      "processor name"
-                       :processor (fn [_] (js/Promise.resolve processor-res))}]
-        (fonda/execute {}
+                       :processor (constantly (js/Promise.resolve processor-res))}]
+        (fonda/execute {:anomaly? true}
                        [processor]
+                       exception-cb-throw
                        success-cb-throw
-                       (fn [anomaly] (is (= processor-res anomaly)) (done))
-                       exception-cb-throw)))))
+                       (fn [anomaly]
+                         (is (= processor-res anomaly))
+                         (done)))))))
 
 (deftest one-exceptional-sync-processor-test
   (testing "Passing one synchronous exceptional processor should call on-exception with the exception"
     (async done
       (let [processor-res (js/Error "Bad exception")
             processor {:path      [:processor-path]
-                       :name      "processor name"
                        :processor (fn [_] (throw processor-res))}]
         (fonda/execute {}
                        [processor]
-                       success-cb-throw
-                       anomaly-cb-throw
-                       (fn [err] (is (= processor-res err)) (done)))))))
+                       (fn [err]
+                         (is (= processor-res err))
+                         (done))
+                       success-cb-throw)))))
 
 (deftest one-exceptional-sync-tap-test
   (testing "Passing one synchronous exceptional tap should call on-exception with the exception"
     (async done
       (let [tap-res (js/Error "Bad exception")
-            tap {:name "processor name"
-                 :tap  (fn [_] (throw tap-res))}]
+            tap {:tap  (fn [_] (throw tap-res))}]
         (fonda/execute {}
                        [tap]
-                       success-cb-throw
-                       anomaly-cb-throw
-                       (fn [err] (is (= tap-res err)) (done)))))))
+                       (fn [err]
+                         (is (= tap-res err))
+                         (done))
+                       success-cb-throw)))))
 
 (deftest one-exceptional-async-processor-test
   (testing "Passing one asynchronous exceptional processor should call on-anomaly with the anomaly"
     (async done
       (let [processor-res (js/Error "Bad exception")
             processor {:path      [:processor-path]
-                       :name      "processor name"
-                       :processor (fn [_] (js/Promise.reject processor-res))}]
+                       :processor (constantly (js/Promise.reject processor-res))}]
         (fonda/execute {}
                        [processor]
-                       success-cb-throw
-                       anomaly-cb-throw
-                       (fn [err] (is (= processor-res err)) (done)))))))
+                       (fn [err]
+                         (is (= processor-res err))
+                         (done))
+                       success-cb-throw)))))
 
 (deftest multiple-successful-synchronous-steps-test
   (testing "Passing multiple successful synchronous steps should call the on-success callback with the augmented context"
@@ -180,12 +181,13 @@
       (let [step1-val 1
             step2-fn inc]
         (fonda/execute {}
-                       [{:path [:step1] :name "step1" :processor (fn [_] step1-val)}
-                        {:path [:step2] :name "step2" :processor (fn [{:keys [step1]}] (step2-fn step1))}]
+                       [{:path [:step1] :processor (constantly step1-val)}
+                        {:path [:step2] :processor (fn [{:keys [step1]}] (step2-fn step1))}]
+                       exception-cb-throw
                        (fn [res]
-                         (is (= res {:step1 step1-val :step2 (step2-fn step1-val)})) (done))
-                       anomaly-cb-throw
-                       exception-cb-throw)))))
+                         (is (= res {:step1 step1-val
+                                     :step2 (step2-fn step1-val)}))
+                         (done)))))))
 
 (deftest multiple-successful-asynchronous-steps-augmented-context-on-success-test
   (testing "Passing multiple successful asynchronous steps should call the on-success callback with the augmented context"
@@ -194,16 +196,15 @@
             step2-fn inc]
         (fonda/execute {}
                        [{:path      [:step1]
-                         :name      "step1"
-                         :processor (fn [_] (js/Promise.resolve step1-val))}
+                         :processor (constantly (js/Promise.resolve step1-val))}
                         {:path      [:step2]
-                         :name      "step2"
                          :processor (fn [{:keys [step1]}]
                                       (js/Promise.resolve (step2-fn step1)))}]
+                       exception-cb-throw
                        (fn [res]
-                         (is (= res {:step1 step1-val :step2 (step2-fn step1-val)})) (done))
-                       anomaly-cb-throw
-                       exception-cb-throw)))))
+                         (is (= res {:step1 step1-val
+                                     :step2 (step2-fn step1-val)}))
+                         (done)))))))
 
 
 (deftest multiple-successful-asynchronous-and-synchronous-steps-test
@@ -214,133 +215,149 @@
             step3-fn str]
         (fonda/execute {}
                        [{:path      [:step1]
-                         :name      "step1"
-                         :processor (fn [_] (js/Promise.resolve step1-val))}
+                         :processor (constantly (js/Promise.resolve step1-val))}
                         {:path      [:step2]
-                         :name      "step2"
                          :processor (fn [{:keys [step1]}]
                                       (step2-fn step1))}
                         {:path      [:step3]
-                         :name      "step3"
                          :processor (fn [{:keys [step2]}]
                                       (step3-fn step2))}]
+                       exception-cb-throw
                        (fn [res]
                          (is (= res {:step1 step1-val
                                      :step2 (step2-fn step1-val)
-                                     :step3 (-> step1-val (step2-fn) (step3-fn))})) (done))
-                       anomaly-cb-throw
-                       exception-cb-throw)))))
+                                     :step3 (-> step1-val (step2-fn) (step3-fn))}))
+                         (done)))))))
 
 
 (deftest multiple-steps-one-unsuccessful-calls-on-anomaly-test
-  (testing "Passing multiple steps, one of them unsuccessful, it call on-anomaly with the anomaly"
+  (testing "When :anomaly is true and an anomaly occurs"
     (async done
-      (let [unsuccessful-res (anomaly :cognitect.anomalies/incorrect)]
-        (fonda/execute {}
+      (let [unsuccessful-anomaly (anomaly :cognitect.anomalies/incorrect)]
+        (fonda/execute {:anomaly? true}
                        [{:path      [:step1]
-                         :name      "step1"
-                         :processor (fn [_]
-                                      (js/Promise.resolve 1))}
+                         :processor (constantly (js/Promise.resolve 1))}
 
                         {:path      [:step2]
-                         :name      "step2"
-                         :processor (fn [_] unsuccessful-res)}
+                         :processor (constantly unsuccessful-anomaly)}
 
                         {:path      [:step3]
-                         :name      "step3"
-                         :processor (fn [_] 1)}]
+                         :processor (constantly 3)}]
+                       exception-cb-throw
                        success-cb-throw
-                       (fn [anomaly] (is (= unsuccessful-res anomaly)) (done))
-                       exception-cb-throw)))))
+                       (fn [anomaly]
+                         (is (= unsuccessful-anomaly anomaly) "it should call the on-anomaly callback with the anomaly data")
+                         (done)))))))
+
+
+(deftest multiple-steps-on-anomaly-do-not-short-circuit-test
+  (testing "When :anomaly is false and an anomaly occurs"
+    (async done
+      (let [successful-anomaly (anomaly :cognitect.anomalies/incorrect)]
+        (fonda/execute {:anomaly? false}
+                       [{:path      [:step1]
+                         :processor (constantly (js/Promise.resolve 1))}
+
+                        {:path      [:step2]
+                         :processor (constantly successful-anomaly)}
+
+                        {:path      [:step3]
+                         :processor (constantly 3)}]
+                       exception-cb-throw
+                       (fn [ctx]
+                         (is (= {:step1 1
+                                 :step2 successful-anomaly
+                                 :step3 3}
+                                ctx)
+                             "it should call the on-success callback with the anomaly in the context")
+                         (done))
+                       anomaly-cb-throw)))))
+
 
 (deftest multiple-steps-one-unsuccessful-short-circuits-test
-  (testing "Passing multiple steps, one of them unsuccessful, it call on-anomaly with the anomaly"
+  (testing "When :anomaly is true and an anomaly occurs"
     (async done
       (let [unsuccessful-res (anomaly :cognitect.anomalies/incorrect)
             step1-counter (atom 0)
             step3-counter (atom 0)]
-        (fonda/execute {}
+        (fonda/execute {:anomaly? true}
                        [{:path      [:step1]
-                         :name      "step1"
                          :processor (fn [_]
                                       (js/Promise.resolve (swap! step1-counter inc)))}
 
                         {:path      [:step2]
-                         :name      "step2"
                          :processor (fn [_] unsuccessful-res)}
 
                         {:path      [:step3]
-                         :name      "step3"
                          :processor (fn [_] (swap! step3-counter inc))}]
+                       exception-cb-throw
                        success-cb-throw
-                       (fn [anomaly] (is (and (= 1 @step1-counter)
-                                              (= 0 @step3-counter))) (done))
-                       exception-cb-throw)))))
+                       (fn [anomaly]
+                         (is (and (= 1 @step1-counter)
+                                  (= 0 @step3-counter))
+                             "it should not call the previous but not the subsequent steps")
+                         (done)))))))
 
 (deftest multiple-steps-one-exceptional-calls-on-exception-test
-  (testing "Passing multiple steps, one of them unsuccessful, it call on-anomaly with the anomaly"
+  (testing "When an exception occurs"
     (async done
       (let [exception (js/Error "Bad exception")]
         (fonda/execute {}
                        [{:path      [:step1]
-                         :name      "step1"
                          :processor (fn [_]
                                       (js/Promise.resolve 1))}
 
                         {:path      [:step2]
-                         :name      "step2"
                          :processor (fn [_] (throw exception))}
 
                         {:path      [:step3]
-                         :name      "step3"
                          :processor (fn [_] 1)}]
-                       success-cb-throw
-                       anomaly-cb-throw
-                       (fn [err] (is (= exception err)) (done)))))))
+                       (fn [err]
+                         (is (= exception err) "it should call on-exception passing the js/Error")
+                         (done))
+                       success-cb-throw)))))
 
 (deftest multiple-steps-one-exceptional-short-circuits-test
-  (testing "Passing multiple steps, one of them unsuccessful, it short-circuits"
+  (testing "When an exception occurs"
     (async done
       (let [exception (js/Error "Bad exception")
             step1-counter (atom 0)
             step3-counter (atom 0)]
         (fonda/execute {}
                        [{:path      [:step1]
-                         :name      "step1"
                          :processor (fn [_]
                                       (js/Promise.resolve (swap! step1-counter inc)))}
 
                         {:path      [:step2]
-                         :name      "step2"
                          :processor (fn [_] (js/Promise.reject exception))}
 
                         {:path      [:step3]
-                         :name      "step1"
                          :processor (fn [_] (swap! step3-counter inc))}]
-                       success-cb-throw
-                       anomaly-cb-throw
-                       (fn [err] (is (and (= 1 @step1-counter)
-                                          (= 0 @step3-counter))) (done)))))))
+                       (fn [err]
+                         (is (and (= 1 @step1-counter)
+                                  (= 0 @step3-counter))
+                             "it should not call the previous but not the subsequent steps")
+                         (done))
+                       success-cb-throw)))))
 
 (deftest multiple-steps-one-exceptional-tap-short-circuits-test
-  (testing "Passing multiple steps and one unsuccessful tap, it call short-circuits"
+  (testing "When an exception in a tap occurs"
     (async done
       (let [exception (js/Error "Bad exception")
             step1-counter (atom 0)
             step3-counter (atom 0)]
         (fonda/execute {}
                        [{:path      [:step1]
-                         :name      "step1"
                          :processor (fn [_]
                                       (js/Promise.resolve (swap! step1-counter inc)))}
 
-                        {:name "step2"
-                         :tap  (fn [_] (js/Promise.reject exception))}
+                        {:tap  (fn [_] (js/Promise.reject exception))}
 
                         {:path      [:step3]
-                         :name      "step1"
                          :processor (fn [_] (swap! step3-counter inc))}]
-                       success-cb-throw
-                       exception-cb-throw
-                       (fn [err] (is (and (= 1 @step1-counter)
-                                          (= 0 @step3-counter))) (done)))))))
+                       (fn [err]
+                         (is (and (= 1 @step1-counter)
+                                  (= 0 @step3-counter))
+                             "it should not call the previous but not the subsequent steps")
+                         (done))
+                       success-cb-throw)))))

--- a/test/fonda/execute_test.cljs
+++ b/test/fonda/execute_test.cljs
@@ -1,0 +1,21 @@
+(ns fonda.execute-test
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [fonda.execute :as execute]
+            [fonda.execute.specs]
+            [orchestra-cljs.spec.test :as orchestra]))
+
+(orchestra/instrument)
+
+(deftest anomaly-fn-tests
+  (let [anomaly-fn (execute/anomaly-fn true)]
+    (is (some? (anomaly-fn {:cognitect.anomalies/anomaly {}})) "it should return the cognitect anomaly predicate when true"))
+
+  (is (nil? (execute/anomaly-fn nil)) "it should return the nil when nil")
+  (is (nil? (execute/anomaly-fn false)) "it should return the nil when false")
+
+  (let [anomaly-fn (execute/anomaly-fn
+                    (fn [m]
+                      (::anomaly m)))]
+    (is (some? (anomaly-fn {::anomaly :foo})) "it should return the custom anomaly predicate when set"))
+
+  (is (thrown? js/Error (execute/anomaly-fn "what?") "it should throw if passed something that is not a function")))

--- a/test/fonda/test_preload.cljs
+++ b/test/fonda/test_preload.cljs
@@ -1,0 +1,6 @@
+(ns fonda.test-preload
+  (:require [cljs.spec.alpha :as s]
+            [cljs.test :as test]
+            [expound.alpha :as expound]))
+
+(set! s/*explain-out* (expound/custom-printer {:theme :figwheel-theme}))


### PR DESCRIPTION
A user of the library might not need to use anomalies but just need to throw on
exceptions. This patch makes the anomaly machinery optional.

When the :anomaly? config key is truthy we now enable the functionality.

The patch is *Breaking* as it also changes the signature of
`fonda.core/execute` for a more node-friendly callback style - `on-exception`
first then `on-success`.